### PR TITLE
Fix project slug in README.md

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -1,6 +1,6 @@
 # {{cookiecutter.project_name}}
 
-| [Documentation](https://{{cookiecutter.github_org_name}}.github.io/{{cookiecutter.__repo_name}}) |
+| [Documentation](https://{{cookiecutter.github_org_name}}.github.io/{{cookiecutter.__project_slug}}) |
 
 {{cookiecutter.project_description}}
 **TODO: Add more detailed information about the project**


### PR DESCRIPTION
Quick fix to change __repo_name to __project_slug in README.md